### PR TITLE
Deploy artifacts when current branch is main

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -70,18 +70,19 @@ jobs:
 
       - name: Deploy artifacts
         id: deploy
+        if: github.ref == 'refs/heads/main'
         run: ./deploy.sh
 
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.39.0
-        if: steps.deploy.outputs.RELEASE == 'true'
+        if: steps.deploy.outputs.RELEASE == 'true' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: ${{ steps.deploy.outputs.TAGNAME }}
 
       - name: Deploy Java Doc
         uses: JamesIves/github-pages-deploy-action@v4.4.0
-        if: steps.deploy.outputs.RELEASE == 'true'
+        if: steps.deploy.outputs.RELEASE == 'true' && github.ref == 'refs/heads/main'
         with:
           branch: gh-pages
           folder: "build/docs/javadoc/"


### PR DESCRIPTION
This will result in deployment only after the merge, which will reduce the number of deployments since they were running every time on every PR.