### PR TITLE
Update guava to version 32.1.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,14 +15,14 @@ plugins {
 
 dependencies {
 	implementation 'org.slf4j:slf4j-api:2.0.7'
-	implementation 'com.google.guava:guava:32.0.1-jre'
+	implementation 'com.google.guava:guava:32.1.1-jre'
 	implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'io.gsonfire:gson-fire:1.8.5'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
 	testImplementation 'io.github.cdimascio:dotenv-java:2.3.0'
-	testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.35.0'
+	testImplementation 'com.github.tomakehurst:wiremock-jre8:2.35.0'
 	testImplementation 'org.mockito:mockito-core:4.11.0'
 	testImplementation 'org.hamcrest:hamcrest:2.2'
 	testRuntimeOnly 'ch.qos.logback:logback-classic:1.3.8'

--- a/src/test/java/com/acrolinx/client/sdk/AcrolinxEndpointTests.java
+++ b/src/test/java/com/acrolinx/client/sdk/AcrolinxEndpointTests.java
@@ -186,7 +186,6 @@ class AcrolinxEndpointTests
 
         try (AcrolinxEndpoint acrolinxEndpoint = new AcrolinxEndpoint(acrolinxHttpClient,
                 new URI("https://www.acrolinx.com/proxy"), "foo", "1.2.3.97", "bar")) {
-
             AcrolinxException acrolinxException = Assertions.assertThrows(AcrolinxException.class,
                     () -> acrolinxEndpoint.getPlatformInformation());
             assertEquals("Fetch failed with status 700 and no result.", acrolinxException.getMessage());


### PR DESCRIPTION
Use wiremock-jre8 instead of wiremock-jre8-standalone